### PR TITLE
Add customizable node value accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ If *iterations* is specified, sets the number of relaxation iterations when [gen
 If *ignoredNodes* is specified, sets a list of nodes ids to ignore when resolving collisions, which excludes said nodes when calculating their positions,and return this Sankey generator.
 If *ignoredNodes* is not specified, returns the current ignored nodes, which defaults to an empty list.
 
+<a name="sankey_nodeValue" href="#sankey_nodeValue">#</a> <i>sankey</i>.<b>nodeValue</b>([<i>nodeId</i>]) [<>](https://github.com/headstart-app/d3-sankey/blob/master/src/sankey.js#L113 "Source")
+
+If *nodeValue* is specified, sets the node value accessor to the specified function and returns this Sankey generator. If *nodeValue* is not specified, then the node value is calculated by making the sum of all the values in the source links and in the target links. If the value is different between the two, then the bigger number is used.
+
 ### Alignments
 
 See [*sankey*.nodeAlign](#sankey_nodeAlign).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-sankey",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Visualize flow between nodes in a directed acyclic network.",
   "keywords": [
     "d3",

--- a/src/sankey.js
+++ b/src/sankey.js
@@ -35,6 +35,13 @@ function defaultId(d) {
   return d.index;
 }
 
+function defaultNodeValue(d) {
+  return Math.max(
+    sum(d.sourceLinks, value),
+    sum(d.targetLinks, value),
+  );
+}
+
 function defaultNodes(graph) {
   return graph.nodes;
 }
@@ -54,6 +61,7 @@ export default function() {
       dx = 24, // nodeWidth
       py = 8, // nodePadding
       id = defaultId,
+      nodeValue = defaultNodeValue,
       align = justify,
       nodes = defaultNodes,
       links = defaultLinks,
@@ -76,6 +84,10 @@ export default function() {
 
   sankey.nodeId = function(_) {
     return arguments.length ? (id = typeof _ === "function" ? _ : constant(_), sankey) : id;
+  };
+
+  sankey.nodeValue = function (_) {
+    return arguments.length ? (nodeValue = typeof _ === "function" ? _ : constant(_), sankey) : nodeValue;
   };
 
   sankey.nodeAlign = function(_) {
@@ -131,11 +143,8 @@ export default function() {
 
   // Compute the value (size) of each node by summing the associated links.
   function computeNodeValues(graph) {
-    graph.nodes.forEach(function(node) {
-      node.value = Math.max(
-        sum(node.sourceLinks, value),
-        sum(node.targetLinks, value)
-      );
+    graph.nodes.forEach(function (node) {
+      node.value = nodeValue(node);
     });
   }
 

--- a/src/sankey.js
+++ b/src/sankey.js
@@ -89,15 +89,11 @@ export default function () {
     return arguments.length ? (id = typeof _ === "function" ? _ : constant(_), sankey) : id;
   };
 
-<<<<<<< HEAD
   sankey.nodeValue = function (_) {
     return arguments.length ? (nodeValue = typeof _ === "function" ? _ : constant(_), sankey) : nodeValue;
   };
 
-  sankey.nodeAlign = function(_) {
-=======
   sankey.nodeAlign = function (_) {
->>>>>>> master
     return arguments.length ? (align = typeof _ === "function" ? _ : constant(_), sankey) : align;
   };
 
@@ -173,14 +169,7 @@ export default function () {
   // Compute the value (size) of each node by summing the associated links.
   function computeNodeValues(graph) {
     graph.nodes.forEach(function (node) {
-<<<<<<< HEAD
       node.value = nodeValue(node);
-=======
-      node.value = Math.max(
-        sum(node.sourceLinks, value),
-        sum(node.targetLinks, value)
-      );
->>>>>>> master
     });
   }
 


### PR DESCRIPTION
- Add configurable accessor function to override the way the library calculates the total value of a node. This way it's possible to exclude links from the diagram but keeping them in the total value so that the node size is calculated accordingly.